### PR TITLE
docs: expand zensical site coverage

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,127 @@
+# Configuration
+
+The plugin is configured through the standard `PLUGINS_CONFIG` mechanism in
+NetBox `configuration.py`. All settings are optional. Sensible defaults are
+declared in the plugin's `PluginConfig.default_settings`.
+
+## Settings reference
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_peering_manager": {
+        "top_level_menu": True,
+        "peeringdb_url": None,
+        "peeringdb_api_key": None,
+        "peeringdb_timeout": None,
+        "peeringdb_local_asns": [],
+    },
+}
+```
+
+| Setting                 | Type            | Default                          | Description |
+|-------------------------|-----------------|----------------------------------|-------------|
+| `top_level_menu`        | bool            | `True`                           | When true, expose a dedicated "Peering" top-level menu with Peering / Fabrics / IRR groups. When false, links are flattened into the main plugins menu. |
+| `peeringdb_url`         | str or None     | `None` (`https://www.peeringdb.com/api`) | Override the PeeringDB API base URL. Useful for local mirrors or paid private instances. |
+| `peeringdb_api_key`     | str or None     | `None`                           | PeeringDB API key. Sent as `Authorization: Api-Key <value>`. Required only for fields that PeeringDB gates behind authentication (contact emails, some operational data). |
+| `peeringdb_timeout`     | int or None     | `30`                             | HTTP timeout in seconds for PeeringDB requests. |
+| `peeringdb_local_asns`  | list[int]       | `[]`                             | ASNs your organization owns. Listed ASNs are excluded from the cached `PeeringDBPeer` table during sync so you do not import yourself as a peer. |
+
+The PeeringDB client also reads an undocumented `peeringdb_rate_limit` key
+(seconds between requests, default 2.0) directly via `get_plugin_config`.
+Set it explicitly if you operate a private PeeringDB mirror with looser
+rate limits or, conversely, if you want to be a more conservative client.
+
+## Recommended baseline
+
+For a typical production install with PeeringDB and a single home ASN:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_peering_manager": {
+        "top_level_menu": True,
+        "peeringdb_api_key": "PDB-XXXXXXXXXXXXXXXX",
+        "peeringdb_timeout": 60,
+        "peeringdb_local_asns": [64500],
+    },
+}
+```
+
+If you operate multiple ASNs (transit subsidiaries, an experimental ASN,
+etc.) put all of them into `peeringdb_local_asns`. They will be filtered
+out of every IX peer cache.
+
+## Storing secrets
+
+`peeringdb_api_key` is a secret. Read it from an environment variable or a
+secrets manager rather than committing it to `configuration.py`:
+
+```python
+import os
+
+PLUGINS_CONFIG = {
+    "netbox_peering_manager": {
+        "peeringdb_api_key": os.environ.get("PEERINGDB_API_KEY"),
+    },
+}
+```
+
+In Docker / Kubernetes deployments, mount the key as an environment variable
+on the NetBox web container and the RQ worker container. The PeeringDB
+client is constructed inside the request / job lifecycle, so both
+processes need access to the key.
+
+## Top-level menu vs. flattened menu
+
+The plugin emits a `PluginMenu` with three groups:
+
+- **Peering**: Peering Sessions, Peer ASNs, Relationship Types.
+- **Fabrics**: Fabric Types, Fabrics, Create from PeeringDB, Networks,
+  Connections.
+- **IRR**: IRR Sources, IRR Prefix List Configs.
+
+This is the layout used when `top_level_menu = True`. With
+`top_level_menu = False`, the same items are emitted as a flat
+`menu_items` tuple, which NetBox displays under the generic Plugins menu.
+The flattened layout is fine for sandbox installs but the grouped layout
+scales better once you have more than a handful of fabrics.
+
+## RQ worker
+
+IRR sync jobs (`SyncPrefixListJob`, `SyncAllPrefixListsJob`) are NetBox
+`JobRunner` tasks. They run inside the standard NetBox RQ worker process.
+Make sure that worker is running and has access to:
+
+- The NetBox database (it writes `PrefixListEntry` rows back).
+- Whatever fastbgpq4 endpoint you configured on each `IRRSource`.
+
+In the bundled devcontainer / Makefile, the worker is started with
+`make rqworker`. In production, make sure your `netbox-rq` systemd unit (or
+equivalent) is running.
+
+## Verifying configuration
+
+```bash
+cd /opt/netbox/netbox
+python manage.py nbshell
+```
+
+```python
+from django.conf import settings
+settings.PLUGINS_CONFIG["netbox_peering_manager"]
+# {'top_level_menu': True, 'peeringdb_url': None, 'peeringdb_api_key': '***', ...}
+
+from netbox_peering_manager.services import PeeringDBClient
+client = PeeringDBClient()
+client.get_ix(31)  # 31 = LINX in PeeringDB
+```
+
+A successful response confirms that the API URL, timeout, and API key are
+all wired up correctly. A 401 means your API key is wrong; a 429 means
+rate limiting kicked in (the client backs off and retries automatically up
+to three times).
+
+## Next: bring up your first fabric
+
+Once the plugin is configured, the next step is
+[creating your first peering fabric](first-fabric.md) - either from
+scratch or by importing one from PeeringDB.

--- a/docs/getting-started/first-fabric.md
+++ b/docs/getting-started/first-fabric.md
@@ -1,0 +1,116 @@
+# Your first peering fabric
+
+A **PeeringFabric** represents a shared peering environment: an Internet
+Exchange, a cloud exchange, or a private peering LAN. It carries metadata
+(name, type, status, site, tenant), an optional default
+`netbox_routing.BGPPeerTemplate` to use as a peer group baseline, and an
+optional one-to-one link to PeeringDB through `PeeringFabricPeeringDB`.
+
+There are two paths to your first fabric: import one from PeeringDB
+(recommended for real IXes), or build one by hand for a private LAN that
+PeeringDB does not know about.
+
+## Path 1: import from PeeringDB
+
+This is the fast path. The plugin ships a dedicated view that searches
+PeeringDB by IX name, lets you pick one, and creates a fabric prefilled
+from PeeringDB data.
+
+1. Navigate to **Peering &rarr; Fabrics &rarr; Create from PeeringDB**.
+2. Type at least two characters of the IX name in the search box. The
+   AJAX endpoint at `/plugins/bgp/peeringdb/search/` calls
+   `PeeringDBClient.search_ix` and returns up to 20 matches.
+3. Pick the IX. Submit.
+4. The view calls `PeeringFabric.objects.create()` with the PeeringDB
+   name, then `link_fabric_to_peeringdb(fabric, ix_id, sync=True)` which:
+   - Creates the `PeeringFabricPeeringDB` link record.
+   - Runs a full PeeringDB sync (IX details, IXLANs as PeeringNetworks,
+     peers cached as `PeeringDBPeer`).
+
+You land on the new fabric's detail page with PeeringDB metadata, networks,
+and a peer cache populated. From the shell, the same flow looks like:
+
+```python
+from django.utils.text import slugify
+from netbox_peering_manager.models import PeeringFabric
+from netbox_peering_manager.services import PeeringDBClient, link_fabric_to_peeringdb
+
+client = PeeringDBClient()
+ix = client.get_ix(31)  # LINX
+
+fabric = PeeringFabric.objects.create(
+    name=ix["name"],
+    slug=slugify(ix["name"])[:100],
+    description=f"Imported from PeeringDB IX {ix['id']}",
+)
+result = link_fabric_to_peeringdb(fabric, ix_id=ix["id"], sync=True)
+print(result.networks_created, result.networks_updated, result.peers_synced)
+```
+
+## Path 2: build a private fabric by hand
+
+Use this when you operate a private peering LAN, a metro fabric, or a cloud
+exchange that has no PeeringDB record.
+
+1. Navigate to **Peering &rarr; Fabrics &rarr; Fabric Types &rarr; Add**.
+   Create a type such as `Private Peering LAN` with a recognizable color.
+2. Navigate to **Peering &rarr; Fabrics &rarr; Fabrics &rarr; Add**. Fill
+   in the fabric:
+   - **Name** and **Slug**: e.g. `MTL-PRIV-PEER-1` / `mtl-priv-peer-1`.
+     The model enforces uniqueness on `(name, site)` if a site is set, or
+     just on `name` otherwise.
+   - **Type**: the `PeeringFabricType` you just created.
+   - **Status**: Active, Planned, or Decommissioned (from
+     `PeeringStatusChoices`).
+   - **Site** and **Tenant**: optional, link to NetBox DCIM/tenancy.
+   - **Peer group** (`peer_group`): a `netbox_routing.BGPPeerTemplate` that
+     sessions on this fabric default to. This is a convenience field for
+     templates; nothing enforces it on the data model.
+
+## Add at least one PeeringNetwork
+
+A fabric without a network cannot have peering sessions attached.
+`PeeringNetwork` is the per-LAN object. If you imported from PeeringDB, one
+or more networks already exist (one per IXLAN prefix, named after the
+IXLAN). Otherwise, add one manually:
+
+1. Navigate to **Peering &rarr; Fabrics &rarr; Networks &rarr; Add**.
+2. Pick the fabric. Pick a `Prefix` from IPAM (the L2 LAN prefix, e.g.
+   `198.51.100.0/24`). Optionally pick a `VLAN`.
+3. Set the status. Save.
+
+`PeeringNetwork` has a unique constraint on `(fabric, name)`, so each
+network within a fabric must have a distinct name.
+
+## Add a PeeringConnection
+
+A `PeeringConnection` ties one of your routers to a peering network. It
+records the device interface that physically attaches to the LAN.
+
+1. Navigate to **Peering &rarr; Fabrics &rarr; Connections &rarr; Add**.
+2. Pick the **Peering Network**.
+3. Pick the **Interface** (a `dcim.Interface` on the device that lands on
+   the peering LAN).
+4. Set the status. Save.
+
+The connection's `ip_addresses` property returns NetBox `IPAddress` objects
+on that interface that fall inside the peering network's prefix - useful
+for sanity-checking that you have actually configured a local IP on the
+router before opening sessions.
+
+## Verify
+
+From the fabric's detail page you should now see:
+
+- A `PeeringDB Info` panel (IX ID, city, country, last sync) if linked to
+  PeeringDB.
+- A list of `PeeringNetwork` rows.
+- A list of `PeeringConnection` rows for any of your routers attached to
+  those networks.
+- An empty `PeeringSession` table - sessions are next.
+
+## Next: create your first session
+
+Continue to [your first peering session](first-session.md) to build the
+underlying `BGPPeer` in netbox-routing, wrap it in a `PeeringSession`, and
+attach it to the network.

--- a/docs/getting-started/first-session.md
+++ b/docs/getting-started/first-session.md
@@ -1,0 +1,180 @@
+# Your first peering session
+
+A **PeeringSession** is a thin one-to-one wrapper around a
+`netbox_routing.BGPPeer`. The BGP layer (peer IPs, ASNs, BFD, address
+families, route maps, prefix lists, peer template) is owned by
+netbox-routing. The peering layer adds:
+
+- `relationship` - the kind of session (transit, customer, peer, IXP).
+- `peering_network` - which IX LAN this session sits on (if any).
+- `service_reference` - a free-form string for ticket / order tracking.
+
+This page walks through the full sequence: create the supporting objects,
+build the netbox-routing peer, wrap it with a `PeeringSession`.
+
+## Prerequisites
+
+Before opening a peering session you typically have:
+
+- A `PeeringFabric` and at least one `PeeringNetwork` (see
+  [your first fabric](first-fabric.md)).
+- A `PeeringConnection` from your router to that network so the local IP
+  exists on an interface in NetBox IPAM.
+- A NetBox `ipam.ASN` for the remote peer's AS number (auto-created by
+  PeeringDB sync if you used Path 1, or imported manually from RIPE/ARIN
+  data).
+- A `netbox_routing.BGPRouter` for your local router with a `BGPScope`
+  (global or VRF).
+
+## Step 1: classify the session
+
+Open **Peering &rarr; Relationship Types &rarr; Add** and create the
+relationship taxonomy you want, for example:
+
+| Slug      | Name      | Color    |
+|-----------|-----------|----------|
+| transit   | Transit   | red      |
+| customer  | Customer  | blue     |
+| peer      | Peer      | green    |
+| ixp-rs    | IX Route Server | yellow |
+
+You only need to do this once. Relationship types are reused across every
+session and surface as a colored badge in tables.
+
+## Step 2: capture peer-side metadata
+
+Create a `PeerASN` for the remote peer. This object extends `ipam.ASN`
+with the data you need for prefix lists and templates:
+
+1. Navigate to **Peering &rarr; Peer ASNs &rarr; Add**.
+2. Pick the underlying `ipam.ASN`.
+3. Fill in:
+   - `affiliated`: True if you operate this ASN. Use it for sibling
+     networks or anycast siblings.
+   - `irr_as_set`: The IRR AS-SET you intend to filter against, e.g.
+     `AS-CUSTOMER` or `RIPE::AS-EXAMPLE`.
+   - `ipv4_max_prefixes` / `ipv6_max_prefixes`: per-AFI limits.
+   - `peeringdb_id` (optional): if you populated it manually; the
+     `PeeringDBSyncService.sync_peer_asn()` method fills it in
+     automatically along with prefix limits and the IRR AS-SET.
+
+You can sync everything from PeeringDB in one shot:
+
+```python
+from netbox_peering_manager.models import PeerASN
+from netbox_peering_manager.services import PeeringDBSyncService
+
+service = PeeringDBSyncService()
+peer = PeerASN.objects.get(asn__asn=64500)
+service.sync_peer_asn(peer)
+peer.refresh_from_db()
+print(peer.irr_as_set, peer.ipv4_max_prefixes, peer.ipv6_max_prefixes)
+```
+
+## Step 3: create the underlying BGPPeer
+
+This step lives in netbox-routing. From the UI: **Routing &rarr; BGP &rarr;
+Peers &rarr; Add**. Required fields, in plain English:
+
+- **Scope**: the `BGPScope` on your `BGPRouter`. Sessions are attached to
+  scopes (global table or per-VRF).
+- **Peer**: the remote `IPAddress` (their side of the IX LAN).
+- **Source**: your local `IPAddress` (your side of the IX LAN).
+- **Local AS / Remote AS**: link to `ipam.ASN` records.
+- **Peer group** (`BGPPeerTemplate`): optional. Inherit timers, AFIs,
+  policies. The `peer_group` you set on the parent `PeeringFabric` is a
+  reasonable default.
+- **BFD**, **TTL / multihop**, **password**: as applicable.
+- **Address families**: add `BGPPeerAddressFamily` rows for each AFI/SAFI
+  you want. Attach `RoutingPolicy` (route maps) and `PrefixList` for in /
+  out filtering.
+
+If you prefer the shell:
+
+```python
+from ipam.models import ASN, IPAddress
+from netbox_routing.models import BGPPeer, BGPRouter, BGPScope
+
+router = BGPRouter.objects.get(name="rt1.mtl")
+scope = BGPScope.objects.get(router=router, scope=None)  # global
+
+peer = BGPPeer.objects.create(
+    scope=scope,
+    peer=IPAddress.objects.get(address="198.51.100.42/24"),
+    source=IPAddress.objects.get(address="198.51.100.1/24"),
+    local_as=ASN.objects.get(asn=64500),
+    remote_as=ASN.objects.get(asn=64512),
+    name="AS64512 - Example Peer (LINX)",
+    enabled=True,
+)
+```
+
+## Step 4: wrap with a PeeringSession
+
+Now layer the peering metadata on top.
+
+1. Navigate to **Peering &rarr; Peering Sessions &rarr; Add**.
+2. Pick the `BGPPeer` you just created. The form enforces the one-to-one
+   constraint - each `BGPPeer` can have at most one `PeeringSession`.
+3. Pick the `Relationship` (transit / customer / peer / etc.).
+4. Pick the `PeeringNetwork` (your IX LAN).
+5. Optionally fill in `service_reference` (ticket ID, NOC reference, etc.).
+
+From the shell:
+
+```python
+from netbox_peering_manager.models import (
+    PeeringNetwork, PeeringSession, Relationship,
+)
+
+network = PeeringNetwork.objects.get(fabric__name="LINX LON1", name__startswith="LINX")
+relation = Relationship.objects.get(slug="peer")
+
+PeeringSession.objects.create(
+    bgp_peer=peer,
+    relationship=relation,
+    peering_network=network,
+    service_reference="NOC-12345",
+)
+```
+
+## Step 5: render config
+
+Once a session exists, you can feed it through the
+[configuration templating](../user-guide/configuration-templating.md) flow.
+The fastest way to verify everything is wired up:
+
+```bash
+curl -X POST http://netbox/api/plugins/bgp/render-config/ \
+  -H "Authorization: Token $NETBOX_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"template": 7, "device": 42}'
+```
+
+`template` is the ID of a NetBox `ConfigTemplate` (see the example
+templates under `docs/examples/templates/`). `device` is the device whose
+`BGPRouter` the session lives on. The response contains the rendered
+config plus a `session_count` metadata field.
+
+## What you should see in the UI
+
+- The session row appears on the `PeeringSession` list with relationship
+  badge and service reference.
+- The relationship detail page shows a session table including this row.
+- The peer ASN detail page shows a session table for every session whose
+  remote AS matches.
+- The peering network detail page shows the session under its sessions
+  table and the corresponding `PeeringConnection` if you have one.
+
+## Common pitfalls
+
+- **`BGPPeer` already has a `PeeringSession`.** Each `BGPPeer` is 1:1 with
+  a session. Edit the existing session instead of creating a new one.
+- **`PeeringNetwork` is on the wrong fabric.** Sessions can be attached to
+  any network, but during config rendering the per-session
+  `peering_network.fabric.name` is what shows up in the template context.
+  Pick the correct LAN.
+- **No `PeeringConnection`.** The model graph allows sessions without a
+  matching connection. The UI does not warn about it. If your templates
+  expect `device.interfaces[*].peering_connections` to enumerate sessions,
+  populate a connection too.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,136 @@
+# Installation
+
+netbox-peering-manager is a NetBox plugin and follows the standard NetBox
+plugin install flow. The only non-obvious step is that
+[netbox-routing](https://github.com/DanSheps/netbox-routing) must already
+be installed, enabled, and migrated before you enable this plugin: it
+declares `netbox_routing` as a required plugin and will refuse to load
+otherwise.
+
+## Requirements
+
+- NetBox 4.5.x (the plugin pins `min_version = "4.5.0"` and
+  `max_version = "4.5.99"`).
+- Python 3.12, 3.13, or 3.14.
+- PostgreSQL (whatever NetBox itself supports).
+- A running NetBox RQ worker if you plan to use IRR prefix-list sync jobs
+  (`make rqworker` in the dev setup, or your production worker service).
+- Optional: a running [fastbgpq4](https://github.com/jsenecal/fastbgpq4)
+  instance if you plan to use IRR sync.
+- Optional: a PeeringDB API key if you plan to read fields that PeeringDB
+  gates behind authentication (contact info, etc.).
+
+## Install netbox-routing first
+
+```bash
+source /opt/netbox/venv/bin/activate
+pip install 'netbox-routing>=0.4'
+```
+
+Add it to `PLUGINS` in `configuration.py` and run migrations:
+
+```python
+PLUGINS = [
+    "netbox_routing",
+]
+```
+
+```bash
+cd /opt/netbox/netbox
+python manage.py migrate
+```
+
+Restart NetBox and confirm that the routing models show up in the UI under
+the Routing menu before moving on.
+
+## Install netbox-peering-manager
+
+```bash
+source /opt/netbox/venv/bin/activate
+pip install netbox-peering-manager
+```
+
+Add the plugin to `PLUGINS` in `configuration.py`. Order matters:
+`netbox_routing` must come first, because Django evaluates the `required_plugins`
+declaration during app loading.
+
+```python
+PLUGINS = [
+    "netbox_routing",
+    "netbox_peering_manager",
+]
+```
+
+Run the plugin migrations:
+
+```bash
+cd /opt/netbox/netbox
+python manage.py migrate netbox_peering_manager
+```
+
+Restart NetBox (`systemctl restart netbox netbox-rq` on a typical install).
+You should now see a top-level **Peering** menu in the navigation, with
+sub-menus for Peering, Fabrics, and IRR.
+
+## Pinning for production
+
+Pin both plugins in your `local_requirements.txt` so upgrades are
+deterministic:
+
+```
+netbox-routing==0.4.0
+netbox-peering-manager==0.2.2
+```
+
+Re-run `pip install -r local_requirements.txt && python manage.py migrate`
+after every NetBox or plugin upgrade.
+
+## Verify the install
+
+Open the NetBox shell and confirm the apps and the JobRunners are
+registered:
+
+```bash
+cd /opt/netbox/netbox
+python manage.py nbshell
+```
+
+```python
+from django.apps import apps
+apps.get_app_config("netbox_peering_manager")
+# <BGPConfig: BGP>
+
+from netbox_peering_manager.jobs import SyncPrefixListJob, SyncAllPrefixListsJob
+SyncPrefixListJob.Meta.name
+# 'Sync Prefix List from IRR'
+```
+
+If both lines work, the plugin is loaded correctly.
+
+## Upgrading
+
+The plugin is published to [PyPI](https://pypi.org/project/netbox-peering-manager/).
+Standard upgrade flow:
+
+```bash
+source /opt/netbox/venv/bin/activate
+pip install --upgrade netbox-peering-manager
+cd /opt/netbox/netbox
+python manage.py migrate netbox_peering_manager
+systemctl restart netbox netbox-rq
+```
+
+If you are migrating from v0.1.x (NetBox 4.4) to v0.2.x (NetBox 4.5), see
+the **Upgrading from v0.1.x** section in the project README. That migration
+is destructive: it drops every `netbox_peering_manager_*` table and rebuilds
+them, and assumes you have already migrated your BGP data into
+netbox-routing.
+
+## Next steps
+
+- [Configure the plugin](configuration.md) (PeeringDB credentials, top-level
+  menu, local ASNs).
+- [Create your first peering fabric](first-fabric.md) and pull data from
+  PeeringDB.
+- [Create your first peering session](first-session.md) on top of a
+  netbox-routing BGP peer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,70 @@
 # NetBox Peering Manager
 
-A NetBox plugin for peering session management with PeeringDB and IRR integration. Builds on top of [netbox-routing](https://github.com/DanSheps/netbox-routing) -- this plugin extends those models with peering-specific functionality (relationship types, peering networks, IX/IXP integration, IRR sync) rather than duplicating them.
+A [NetBox](https://github.com/netbox-community/netbox) 4.5+ plugin that turns
+your NetBox install into a source of truth for external BGP peering. It models
+Internet Exchange (IX) infrastructure, peering sessions, peer ASN metadata,
+and Internet Routing Registry (IRR) prefix-list synchronization, and feeds
+all of it into multi-vendor configuration templates.
+
+The plugin is a thin layer on top of
+[netbox-routing](https://github.com/DanSheps/netbox-routing). All the heavy
+BGP modeling (peers, peer templates, prefix lists, route maps, communities,
+BFD profiles) lives in netbox-routing. This plugin adds the peering-specific
+concepts on top: peering fabrics and networks, peer ASN metadata, IRR sync,
+relationship taxonomy, and PeeringDB integration.
+
+## What it gives you
+
+- **Peering fabric and network modeling** for Internet Exchanges, cloud
+  exchanges, and private peering LANs, with PeeringDB-driven discovery.
+- **Peering sessions** layered on `netbox_routing.BGPPeer` so each session
+  has a relationship type, a peering network reference, and a service
+  reference (ticket / order ID).
+- **Peer ASN profiles** that extend `ipam.ASN` with IRR AS-SET, IPv4 / IPv6
+  max-prefix limits, and a PeeringDB network ID.
+- **PeeringDB sync** for IX details, IXLAN networks, and connected peers,
+  with selective import (no global slurp).
+- **IRR prefix-list sync** through [fastbgpq4](https://github.com/jsenecal/fastbgpq4),
+  scheduled as NetBox `JobRunner` jobs against `netbox_routing.PrefixList`
+  entries.
+- **Configuration templating** via NetBox `ConfigTemplate` plus a denormalized
+  context builder and a small set of vendor-agnostic Jinja2 filters
+  (Cisco / Junos out of the box).
+- **REST API** under `/api/plugins/bgp/` for everything the UI exposes,
+  plus a `render-config/` endpoint that returns rendered device configs.
+
+## How the docs are organized
+
+- [Getting Started](getting-started/installation.md) - install, configure,
+  bring up your first fabric and session end to end.
+- [Concepts](concepts/architecture.md) - the model graph, where each piece
+  comes from (this plugin vs. netbox-routing vs. core NetBox), and the
+  reasoning behind it.
+- [User Guide](user-guide/peeringdb-sync.md) - the day-to-day workflows:
+  PeeringDB sync, IRR prefix-list sync, and configuration rendering.
+- [Integrations](integrations/peeringdb.md) - how the plugin talks to
+  PeeringDB, fastbgpq4, and netbox-routing, and what knobs each side exposes.
+- [Reference](reference/rest-api.md) - REST endpoint catalog, Jinja2 filter
+  signatures, management commands.
+- [Development](development/contributing.md) - contributing notes, testing
+  layout, mock patterns.
 
 ## Quick links
 
 - [GitHub repository](https://github.com/jsenecal/netbox-peering-manager)
 - [Issue tracker](https://github.com/jsenecal/netbox-peering-manager/issues)
-- [README installation guide](https://github.com/jsenecal/netbox-peering-manager#installation)
+- [PyPI: netbox-peering-manager](https://pypi.org/project/netbox-peering-manager/)
+- [netbox-routing (required dependency)](https://github.com/DanSheps/netbox-routing)
+- [fastbgpq4 (IRR sync backend)](https://github.com/jsenecal/fastbgpq4)
+- [PeeringDB API documentation](https://docs.peeringdb.com/api_specs/)
+
+## Compatibility at a glance
+
+| NetBox    | Plugin   | netbox-routing | Python    |
+|-----------|----------|----------------|-----------|
+| 4.5.x     | 0.2.x    | 0.4.x+         | 3.12-3.14 |
+| 4.4.x     | 0.1.x    | n/a            | 3.10+     |
+
+`netbox_routing` is a required plugin and must appear before
+`netbox_peering_manager` in `PLUGINS`. See the
+[installation guide](getting-started/installation.md) for the full sequence.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -9,12 +9,41 @@ edit_uri = "edit/main/docs/"
 docs_dir = "."
 nav = [
   { "Home" = "index.md" },
+  { "Getting Started" = [
+    { "Installation" = "getting-started/installation.md" },
+    { "Configuration" = "getting-started/configuration.md" },
+    { "First Peering Fabric" = "getting-started/first-fabric.md" },
+    { "First Peering Session" = "getting-started/first-session.md" },
+  ] },
+  { "Concepts" = [
+    { "Architecture" = "concepts/architecture.md" },
+    { "Models" = "concepts/models.md" },
+  ] },
+  { "User Guide" = [
+    { "PeeringDB Sync" = "user-guide/peeringdb-sync.md" },
+    { "IRR Prefix Lists" = "user-guide/irr-prefix-lists.md" },
+    { "Configuration Templating" = "user-guide/configuration-templating.md" },
+  ] },
+  { "Integrations" = [
+    { "PeeringDB" = "integrations/peeringdb.md" },
+    { "IRR / fastbgpq4" = "integrations/irr.md" },
+    { "netbox-routing" = "integrations/netbox-routing.md" },
+  ] },
+  { "Reference" = [
+    { "REST API" = "reference/rest-api.md" },
+    { "Jinja2 Filters" = "reference/jinja2-filters.md" },
+    { "Management Commands" = "reference/management-commands.md" },
+  ] },
+  { "Development" = "development/contributing.md" },
 ]
 
 [project.theme]
 features = [
   "content.action.edit",
   "content.action.view",
+  "navigation.sections",
+  "navigation.tabs",
+  "navigation.top",
 ]
 
 [[project.theme.palette]]


### PR DESCRIPTION
Substantive expansion of the documentation site, generated by a per-plugin exploration pass that traced models, views, REST API, backends, and management commands. Covers user workflows, configuration references, REST API, and developer guides.

Drafted as PRs to land iteratively -- review piece by piece, edit / drop pages where the prose doesn't match operator reality, trim things better suited to code comments. The agent that drafted this had less context than you do; treat as a starting point.

ASCII-only output, no AI / Claude attribution. Conventional-commits PR title.