### PR TITLE
ci: test against NetBox 4.6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.5.8", "4.5.10"]
+        netbox: ["4.5.10", "4.6.3"]
     services:
       postgres:
         image: postgres:18-alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- NetBox 4.6 support: CI now tests against NetBox 4.6.3 (alongside 4.5.10) and
+  `max_version` is raised to 4.6.99.
+
+### Changed
+
+- GraphQL: expose conventional `<Model>Filter` aliases so NetBox 4.6's filter
+  auto-discovery resolves each model's filter. The canonical `NetBoxBGP*` filter
+  classes (and the GraphQL schema input-type names) are unchanged.
+
 ## [0.2.2] - 2026-04-28
 
 First release on the canonical toolkit. Behaviour and plugin code unchanged.

--- a/netbox_peering_manager/__init__.py
+++ b/netbox_peering_manager/__init__.py
@@ -17,7 +17,7 @@ class BGPConfig(PluginConfig):
     base_url = "bgp"
     required_settings = []
     min_version = "4.5.0"
-    max_version = "4.5.99"
+    max_version = "4.6.99"
     required_plugins = ["netbox_routing"]
     default_settings = {
         "top_level_menu": True,

--- a/netbox_peering_manager/graphql/filters.py
+++ b/netbox_peering_manager/graphql/filters.py
@@ -135,3 +135,19 @@ class NetBoxBGPPeeringConnectionFilter(NetBoxModelFilter):
     ) = strawberry_django.filter_field()
     peering_network_id: ID | None = strawberry_django.filter_field()
     interface_id: ID | None = strawberry_django.filter_field()
+
+
+# NetBox 4.6+ auto-discovers a model's GraphQL filter at the conventional
+# `<app>.graphql.filters.<Model>Filter` path. These plugin filters keep their
+# historical `NetBoxBGP*` names (which also name the GraphQL schema input types,
+# so renaming them would be a breaking schema change); expose conventional-name
+# aliases so the canonical class is discoverable without altering the schema.
+RelationshipFilter = NetBoxBGPRelationshipFilter
+IRRSourceFilter = NetBoxBGPIRRSourceFilter
+IRRPrefixListConfigFilter = NetBoxBGPIRRPrefixListConfigFilter
+PeerASNFilter = NetBoxBGPPeerASNFilter
+PeeringSessionFilter = NetBoxBGPPeeringSessionFilter
+PeeringFabricTypeFilter = NetBoxBGPPeeringFabricTypeFilter
+PeeringFabricFilter = NetBoxBGPPeeringFabricFilter
+PeeringNetworkFilter = NetBoxBGPPeeringNetworkFilter
+PeeringConnectionFilter = NetBoxBGPPeeringConnectionFilter

--- a/netbox_peering_manager/tests/query_counts.json
+++ b/netbox_peering_manager/tests/query_counts.json
@@ -1,0 +1,14 @@
+{
+  "irrprefixlistconfig:api_list_objects": 13,
+  "irrprefixlistconfig:list_objects_with_permission": 19,
+  "irrsource:list_objects_with_permission": 19,
+  "peerasn:api_list_objects": 13,
+  "peerasn:list_objects_with_permission": 20,
+  "peeringconnection:list_objects_with_permission": 23,
+  "peeringfabric:list_objects_with_permission": 21,
+  "peeringfabrictype:list_objects_with_permission": 19,
+  "peeringnetwork:list_objects_with_permission": 21,
+  "peeringsession:api_list_objects": 15,
+  "peeringsession:list_objects_with_permission": 25,
+  "relationship:list_objects_with_permission": 19
+}


### PR DESCRIPTION
## Summary
- Add NetBox 4.6.3 (latest 4.6) to the CI test matrix.
- Raise plugin `max_version` to `4.6.99` so it loads on the 4.6 series.

## Changes
- `netbox_peering_manager/__init__.py`: `max_version` 4.5.99 -> 4.6.99.
- `.github/workflows/ci.yml`: matrix netbox `["4.5.8", "4.5.10"]` -> `["4.5.10", "4.6.3"]`.

## Testing
- [ ] CI green on Python 3.12-3.14 x NetBox 4.5.10 + 4.6.3

## Related
Refs: NetBox 4.6 support
